### PR TITLE
Add wrapper for Microsoft's guidance and transformers

### DIFF
--- a/openbb_chat/llms/guidance_wrapper.py
+++ b/openbb_chat/llms/guidance_wrapper.py
@@ -1,0 +1,37 @@
+import guidance
+import torch
+from transformers import AutoTokenizer, BitsAndBytesConfig
+
+
+class GuidanceWrapper:
+    """Wrapper around `guidance` to be used with HF models."""
+
+    def __init__(self, model_id: str = "openlm-research/open_llama_3b_v2"):
+        """Init method.
+
+        Args:
+            model_id (`str`):
+                Name of the HF model to use.
+        """
+
+        tokenizer = AutoTokenizer.from_pretrained(model_id, use_fast=False)
+
+        bnb_config = BitsAndBytesConfig(
+            load_in_4bit=True,
+            bnb_4bit_use_double_quant=True,
+            bnb_4bit_quant_type="nf4",
+            bnb_4bit_compute_dtype=torch.bfloat16,
+        )
+
+        # set the default language model used to execute guidance programs
+        guidance.llm = guidance.llms.Transformers(
+            model=model_id,
+            tokenizer=tokenizer,
+            quantization_config=bnb_config,
+            device_map={"": 0},
+            trust_remote_code=True,
+        )
+
+    def __call__(self, *args, **kwargs):
+        """Calls `guidance.__call__` passing all the arguments to it."""
+        return guidance(*args, **kwargs)

--- a/tests/llms/test_guidance_wrapper.py
+++ b/tests/llms/test_guidance_wrapper.py
@@ -1,0 +1,13 @@
+from unittest.mock import patch
+
+import pytest
+
+from openbb_chat.llms.guidance_wrapper import GuidanceWrapper
+
+
+@patch("guidance.llms.Transformers")
+@patch("guidance.__call__")
+def test_guidance_wrapper(mocked_transformers, mocked_call):
+    guidance_wrapper = GuidanceWrapper()
+
+    mocked_call.assert_called_once()


### PR DESCRIPTION
The wrapper automatically creates a quantized transformers' model and
its corresponding tokenizer. Then, calling the wrapper calls guidance.

## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
List all the breaking changes introduced by this pull request.
-->

Adds a wrapper for [`guidance`](https://github.com/microsoft/guidance) so that the [`transformers`](https://github.com/huggingface/transformers)  model is automatically configured with the corresponding tokenizer. Then, calling this method is the same as calling `guidance`.

## Before submitting

- [x] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **test your PR locally** with `pytest` command?
- [x] Did you **run pre-commit hooks** with `pre-commit run -a` command?

## Did you have fun?

Make sure you had fun coding 🙃
