### PR TITLE
Add project build for hatchling

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    tags:
+      - "v*.*.*"
 
 jobs:
   pypi-publish:
@@ -18,7 +20,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.10"]
-        poetry-version: ["1.5.1"]
 
     steps:
       - name: Checkout
@@ -29,14 +30,10 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Set up Poetry ${{ matrix.poetry-version }}
-        uses: abatilo/actions-poetry@v2
-        with:
-          poetry-version: ${{ matrix.poetry-version }}
-
       - name: Run build
         run: |
-          poetry build
+          python -m pip install --upgrade build
+          python -m build
 
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ exclude_lines = [
 name = "openbb-chat"
 version = "0.0.1"
 description = "Chat interface for OpenBB"
-authors = ["Daedalus <daedalus314@protonmail.com>"]
+authors = ["GPTStonks <gptstonks@gmail.com>"]
 readme = "README.md"
 packages = [{include = "openbb_chat"}]
 
@@ -64,9 +64,49 @@ accelerate = "^0.21.0"
 bitsandbytes = "^0.41.1"
 sentencepiece = "^0.1.99"
 guidance = "^0.0.64"
-pandas = ">=1.5.0,<2.0.0"
 
 
 [build-system]
-requires = ["poetry-core"]
-build-backend = "poetry.core.masonry.api"
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "openbb-chat"
+version = "0.0.1.post1"
+description = "Deep learning package to support the chat interface for OpenBB"
+authors = [
+  { name="GPTStonks", email="gptstonks@gmail.com" }
+]
+readme = "README.md"
+requires-python = ">=3.10"
+classifiers = [
+  "Programming Language :: Python :: 3",
+  "License :: OSI Approved :: MIT License",
+  "Operating System :: OS Independent",
+]
+dependencies = [
+  "openbb==3.*",
+  "torch==2.*",
+  "torchvision==0.*",
+  "lightning>=2.0.0",
+  "torchmetrics>=0.11.4",
+  "hydra-core==1.*",
+  "hydra-colorlog==1.*",
+  "hydra-optuna-sweeper==1.*",
+  "wandb>=0.15.5",
+  "pyrootutils<1.0.4",
+  "pre-commit>=3.3.3",
+  "rich>=12.6.0,<13.0.0",
+  "pytest>=7.4.0",
+  "transformers>=4.31.0",
+  "peft>=0.4.0",
+  "einops>=0.6.1",
+  "accelerate>=0.21.0",
+  "bitsandbytes>=0.41.1",
+  "sentencepiece>=0.1.99",
+  "guidance>=0.0.64",
+]
+
+[project.urls]
+"Homepage" = "https://github.com/GPTStonks/openbb-chat"
+"Bug Tracker" = "https://github.com/GPTStonks/openbb-chat/issues"


### PR DESCRIPTION
Poetry is not working to build the project with direct dependencies, and
torch cannot be specified in a non-direct way as of today using this
dependency manager. Therefore, the build packages are also included in
pyproject.toml to be compatible with hatchling. The automated workflow
is corrected to use this build mechanism.

## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
List all the breaking changes introduced by this pull request.
-->

Adds dependencies and sections to `pyproject.toml` so that the build can
be created using `hatchling` and not using Poetry. Poetry does not seem to
work when `torch` is a dependency, and direct dependencies cannot be used
with PyPI.

## Before submitting

- [x] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **test your PR locally** with `pytest` command?
- [x] Did you **run pre-commit hooks** with `pre-commit run -a` command?

## Did you have fun?

Make sure you had fun coding 🙃
