### PR TITLE
Add cls pooling to STransformers

### DIFF
--- a/openbb_chat/classifiers/stransformer.py
+++ b/openbb_chat/classifiers/stransformer.py
@@ -15,15 +15,29 @@ class STransformerZeroshotClassifier(AbstractZeroshotClassifier):
         self,
         keys: List[str],
         model_id: str = "sentence-transformers/all-MiniLM-L6-v2",
+        pooling_type: str = "average",
         *args,
         **kwargs,
     ):
-        """Override __init__ to set default model_id."""
+        """Override __init__ to set default model_id.
+
+        Args:
+            pooling_type (`str`):
+                Type of pooling to apply to output embeddings of the model. Only "average" and "cls" supported.
+        """
+        self.pooling_type = pooling_type
         super().__init__(keys, model_id, *args, **kwargs)
 
     def _compute_embed(self, inputs: dict) -> torch.Tensor:
         """Override parent method to use `sentence-transformers` models in HF."""
-        return self._mean_pooling(self.model(**inputs), inputs["attention_mask"])
+        if self.pooling_type == "average":
+            return self._mean_pooling(self.model(**inputs), inputs["attention_mask"])
+        elif self.pooling_type == "cls":
+            return self._cls_pooling(self.model(**inputs))
+        else:
+            raise ValueError(
+                f"pooling_type can only be 'average' or 'cls', but current value is {self.pooling_type}"
+            )
 
     def _mean_pooling(self, model_output: object, attention_mask: torch.Tensor) -> torch.Tensor:
         """
@@ -44,3 +58,18 @@ class STransformerZeroshotClassifier(AbstractZeroshotClassifier):
         return torch.sum(token_embeddings * input_mask_expanded, 1) / torch.clamp(
             input_mask_expanded.sum(1), min=1e-9
         )
+
+    def _cls_pooling(self, model_output: object) -> torch.Tensor:
+        """
+        CLS Pooling - Only CLS embedding used as an overall representation of the text.
+
+        Args:
+            model_output (`object`): output of `sentence-transformers` model in HF.
+
+        Returns:
+            `torch.Tensor`: final embedding computed from the model output.
+        """
+        # Code from https://huggingface.co/BAAI/bge-base-en
+        sentence_embeddings = model_output[0][:, 0]
+        # Normalize embeddings
+        return torch.nn.functional.normalize(sentence_embeddings, p=2, dim=1)

--- a/tests/classifiers/test_stransformers.py
+++ b/tests/classifiers/test_stransformers.py
@@ -38,3 +38,32 @@ def test_classify(
     assert key == "dog"
     assert score == 1
     assert idx == 0
+
+
+@patch("torch.nn.functional.normalize")
+@patch("torch.cat")
+@patch("torch.sum")
+@patch.object(AutoTokenizer, "from_pretrained")
+@patch.object(AutoModel, "from_pretrained")
+def test_classify_clspooling(
+    mocked_automodel_frompretrained,
+    mocked_tokenizer_frompretrained,
+    mocked_torch_sum,
+    mocked_torch_cat,
+    mocked_torch_normalize,
+):
+    mocked_torch_sum.return_value = torch.tensor([1])
+
+    stransformer_zeroshot = STransformerZeroshotClassifier(
+        ["dog", "cat"], model_id="BAAI/bge-base-en", pooling_type="cls"
+    )
+    key, score, idx = stransformer_zeroshot.classify("Here is a dog")
+
+    mocked_automodel_frompretrained.assert_called_once_with("BAAI/bge-base-en")
+    mocked_tokenizer_frompretrained.assert_called_once_with("BAAI/bge-base-en")
+    mocked_torch_sum.assert_called()
+    mocked_torch_cat.assert_called()
+    mocked_torch_normalize.assert_called()
+    assert key == "dog"
+    assert score == 1
+    assert idx == 0


### PR DESCRIPTION
CLS pooling allows to compute the embedding using the CLS embedding already included in many models and presented in BERT. Intuitively, the CLS embedding contains the overall information of the sentence as it has been used during training to perform a classification task.

## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
List all the breaking changes introduced by this pull request.
-->

`STransformerZeroshotClassifier` is modified to include the possibility of using cls pooling instead of average pooling.

## Before submitting

- [x] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **test your PR locally** with `pytest` command?
- [x] Did you **run pre-commit hooks** with `pre-commit run -a` command?

## Did you have fun?

Make sure you had fun coding 🙃
