### PR TITLE
Add ranking method to AbstractZeroshotClassifier

### DIFF
--- a/tests/classifiers/test_roberta.py
+++ b/tests/classifiers/test_roberta.py
@@ -14,7 +14,7 @@ from openbb_chat.classifiers.roberta import RoBERTaZeroshotClassifier
 def test_classify(
     mocked_automodel_frompretrained, mocked_torch_sum, mocked_torch_cat, mocked_torch_normalize
 ):
-    mocked_torch_sum.return_value = torch.tensor([1])
+    mocked_torch_sum.return_value = torch.tensor([1, 0])
 
     roberta_zeroshot = RoBERTaZeroshotClassifier(["dog", "cat"])
     key, score, idx = roberta_zeroshot.classify("Here is a dog")
@@ -26,3 +26,24 @@ def test_classify(
     assert key == "dog"
     assert score == 1
     assert idx == 0
+
+
+@patch("torch.nn.functional.normalize")
+@patch("torch.cat")
+@patch("torch.sum")
+@patch.object(AutoModel, "from_pretrained")
+def test_rank(
+    mocked_automodel_frompretrained, mocked_torch_sum, mocked_torch_cat, mocked_torch_normalize
+):
+    mocked_torch_sum.return_value = torch.tensor([1, 0])
+
+    roberta_zeroshot = RoBERTaZeroshotClassifier(["dog", "cat"])
+    keys, scores, indices = roberta_zeroshot.rank_k("Here is a dog", k=1)
+
+    mocked_automodel_frompretrained.assert_called_once_with("roberta-base")
+    mocked_torch_sum.assert_called()
+    mocked_torch_cat.assert_called()
+    mocked_torch_normalize.assert_called()
+    assert keys[0] == "dog"
+    assert scores[0] == 1
+    assert indices[0] == 0


### PR DESCRIPTION
The ranking method allows returning a list containing the k most similar keys given a query. This allows not depending on only one key but instead letting the LLM reason which one is best to use.

## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
List all the breaking changes introduced by this pull request.
-->

This PR introduces a ranking method that allows returning more than one value per query.

## Before submitting

- [x] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **test your PR locally** with `pytest` command?
- [x] Did you **run pre-commit hooks** with `pre-commit run -a` command?

## Did you have fun?

Make sure you had fun coding 🙃
