### PR TITLE
Add key loading from file to AbstractZeroshotClassifier

### DIFF
--- a/openbb_chat/classifiers/roberta.py
+++ b/openbb_chat/classifiers/roberta.py
@@ -11,7 +11,7 @@ from openbb_chat.classifiers.abstract_zeroshot_classifier import (
 class RoBERTaZeroshotClassifier(AbstractZeroshotClassifier):
     """Zero-shot classifier based on `sentence-transformers`."""
 
-    def __init__(self, keys: List[str], model_id: str = "roberta-base", *args, **kwargs):
+    def __init__(self, keys: List[str] | str, model_id: str = "roberta-base", *args, **kwargs):
         """Override __init__ to set default model_id."""
         super().__init__(keys, model_id, *args, **kwargs)
 

--- a/openbb_chat/classifiers/stransformer.py
+++ b/openbb_chat/classifiers/stransformer.py
@@ -13,7 +13,7 @@ class STransformerZeroshotClassifier(AbstractZeroshotClassifier):
 
     def __init__(
         self,
-        keys: List[str],
+        keys: List[str] | str,
         model_id: str = "sentence-transformers/all-MiniLM-L6-v2",
         pooling_type: str = "average",
         *args,

--- a/tests/classifiers/test_roberta.py
+++ b/tests/classifiers/test_roberta.py
@@ -1,3 +1,5 @@
+import os
+import tempfile
 from unittest.mock import patch
 
 import pytest
@@ -47,3 +49,24 @@ def test_rank(
     assert keys[0] == "dog"
     assert scores[0] == 1
     assert indices[0] == 0
+
+
+@patch("torch.nn.functional.normalize")
+@patch("torch.sum")
+@patch.object(AutoModel, "from_pretrained")
+def test_classify_embeddings(
+    mocked_automodel_frompretrained, mocked_torch_sum, mocked_torch_normalize
+):
+    mocked_torch_sum.return_value = torch.tensor([1, 0])
+    temp_embeds_file = os.path.join(tempfile.gettempdir(), "embeds.pt")
+    torch.save(torch.randn((6, 10)), temp_embeds_file)
+
+    roberta_zeroshot = RoBERTaZeroshotClassifier(temp_embeds_file)
+    key, score, idx = roberta_zeroshot.classify("Here is a dog")
+
+    mocked_automodel_frompretrained.assert_called_once_with("roberta-base")
+    mocked_torch_sum.assert_called()
+    mocked_torch_normalize.assert_called()
+    assert key.shape == (10,)
+    assert score == 1
+    assert idx == 0

--- a/tests/classifiers/test_stransformers.py
+++ b/tests/classifiers/test_stransformers.py
@@ -1,3 +1,5 @@
+import os
+import tempfile
 from unittest.mock import patch
 
 import pytest
@@ -100,3 +102,35 @@ def test_rank(
     assert keys[0] == "dog"
     assert scores[0] == 1
     assert indices[0] == 0
+
+
+@patch("torch.nn.functional.normalize")
+@patch("torch.clamp")
+@patch("torch.sum")
+@patch.object(AutoTokenizer, "from_pretrained")
+@patch.object(AutoModel, "from_pretrained")
+def test_classify_embeddings(
+    mocked_automodel_frompretrained,
+    mocked_tokenizer_frompretrained,
+    mocked_torch_sum,
+    mocked_torch_clamp,
+    mocked_torch_normalize,
+):
+    mocked_torch_sum.return_value = torch.tensor([1])
+    temp_embeds_file = os.path.join(tempfile.gettempdir(), "embeds.pt")
+    torch.save(torch.randn((6, 10)), temp_embeds_file)
+
+    stransformer_zeroshot = STransformerZeroshotClassifier(temp_embeds_file)
+    key, score, idx = stransformer_zeroshot.classify("Here is a dog")
+
+    mocked_automodel_frompretrained.assert_called_once_with(
+        "sentence-transformers/all-MiniLM-L6-v2"
+    )
+    mocked_tokenizer_frompretrained.assert_called_once_with(
+        "sentence-transformers/all-MiniLM-L6-v2"
+    )
+    mocked_torch_sum.assert_called()
+    mocked_torch_normalize.assert_called()
+    assert key.shape == (10,)
+    assert score == 1
+    assert idx == 0


### PR DESCRIPTION
The keys can now be loaded from a pre-computed PyTorch file, instead of computing them from a list of strings.

## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
List all the breaking changes introduced by this pull request.
-->

Key loading from files allow using pre-computed embeddings instead of computing them on-the-fly. The change is backwards compatible.

## Before submitting

- [x] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **test your PR locally** with `pytest` command?
- [x] Did you **run pre-commit hooks** with `pre-commit run -a` command?

## Did you have fun?

Make sure you had fun coding 🙃
