### PR TITLE
Add AutoLlamaIndex with basic configuration options

### DIFF
--- a/openbb_chat/kernels/auto_llama_index.py
+++ b/openbb_chat/kernels/auto_llama_index.py
@@ -1,0 +1,215 @@
+from typing import List, Optional
+
+import guidance
+import torch
+from llama_index import (
+    ServiceContext,
+    SimpleDirectoryReader,
+    StorageContext,
+    VectorStoreIndex,
+    get_response_synthesizer,
+    set_global_handler,
+    set_global_service_context,
+)
+from llama_index.indices.postprocessor import SimilarityPostprocessor
+from llama_index.indices.query.schema import QueryType
+from llama_index.llms import HuggingFaceLLM, OpenAI
+from llama_index.llms.base import LLM
+from llama_index.prompts import PromptTemplate
+from llama_index.query_engine import RetrieverQueryEngine
+from llama_index.response.schema import RESPONSE_TYPE
+from llama_index.retrievers import BM25Retriever, VectorIndexRetriever
+from llama_index.schema import NodeWithScore
+from transformers import AutoTokenizer, BitsAndBytesConfig
+
+
+class AutoLlamaIndex:
+    """Wrapper around `llama-index` that fixes its possibilities to the ones needed for `openbb-
+    chat`.
+
+    Args:
+        path_to_sdk_docs (`str`):
+            Path to SDK documentation. The folder is processed recursively.
+        embedding_model_id (`str`):
+            Name of the Embedding model to use following `llama-index` convention.
+        llm_model (`str | llama_index.llms.base.LLM`):
+            It can be specified in two possible ways:
+            - Name of the LLM to use. For now, only OpenAI and Hugging Face models are supported.
+                The model should be in the format `openai:{model_name}` or `hf:{model_name}`.
+            - Instance of a `llama-index` compatible LLM, for models other than OpenAI and Hugging Face.
+        context_window (`int`):
+            Context window to use with Hugging Face models.
+        tokenizer_name (`Optional[str]`):
+            For Hugging Face models. By default set to the llm_model id.
+        generate_kwargs (`Optional[dict]`):
+            For Hugging Face models. These kwargs are passed directly to `AutoModelForCausalLM.generate` method.
+        tokenizer_kwargs (`Optional[dict]`):
+            For Hugging Face models. These kwargs are passed directly to `AutoTokenizer`.
+        model_kwargs (`Optional[dict]`):
+            For Hugging Face models. These kwargs are passed directly to `AutoModelForCausalLM.from_pretrained`, apart from
+            `device_map` which should be specified in `other_llama_index_llm_kwargs`.
+        qa_template_str (`Optional[str]`):
+            String representation of the LlamaIndex's QA template to use.
+        refine_template_str (`Optional[str]`):
+            String representation of the LlamaIndex's refine template to use.
+        other_llama_index_llm_kwargs (`dict`):
+            Overrides the default values in LlamaIndex's `LLM`
+        other_llama_index_simple_directory_reader_kwargs (`dict`):
+            Overrides the default values in LlamaIndex's `SimpleDirectoryReader`.
+        other_llama_index_service_context_kwargs (`dict`):
+            Overrides the default values in LlamaIndex's `ServiceContext.from_defaults`.
+        other_llama_index_storage_context_kwargs (`dict`):
+            Overrides the default values in LlamaIndex's `StorageContext.from_defaults`.
+        other_llama_index_vector_store_index_kwargs (`dict`):
+            Overrides the default values in LlamaIndex's `VectorStoreIndex`.
+        other_llama_index_vector_index_retriever_kwargs (`dict`):
+            Overrides the default values in LlamaIndex's `VectorIndexRetriever`.
+        other_llama_index_response_synthesizer_kwargs (`dict`):
+            Overrides the default values in LlamaIndex's `get_response_synthesizer`.
+        other_llama_index_retriever_query_engine_kwargs (`dict`):
+            Overrides the default values in LlamaIndex's `RetrieverQueryEngine`.
+    """
+
+    def __init__(
+        self,
+        path_to_sdk_docs: str,
+        embedding_model_id: str,
+        llm_model: str | LLM,
+        context_window: int = 1024,
+        tokenizer_name: Optional[str] = None,
+        generate_kwargs: Optional[dict] = None,
+        tokenizer_kwargs: Optional[dict] = None,
+        model_kwargs: Optional[dict] = None,
+        qa_template_str: Optional[str] = None,
+        refine_template_str: Optional[str] = None,
+        other_llama_index_llm_kwargs: dict = {},
+        other_llama_index_simple_directory_reader_kwargs: dict = {},
+        other_llama_index_service_context_kwargs: dict = {},
+        other_llama_index_storage_context_kwargs: dict = {},
+        other_llama_index_vector_store_index_kwargs: dict = {},
+        other_llama_index_vector_index_retriever_kwargs: dict = {},
+        other_llama_index_response_synthesizer_kwargs: dict = {},
+        other_llama_index_retriever_query_engine_kwargs: dict = {},
+    ):
+        """Init method."""
+
+        docs_sdk = SimpleDirectoryReader(
+            path_to_sdk_docs, recursive=True, **other_llama_index_simple_directory_reader_kwargs
+        ).load_data()
+
+        llm = self._create_llama_index_llm(
+            llm_model=llm_model,
+            context_window=context_window,
+            generate_kwargs=generate_kwargs,
+            tokenizer_name=tokenizer_name,
+            tokenizer_kwargs=tokenizer_kwargs,
+            model_kwargs=model_kwargs,
+            other_llama_index_llm_kwargs=other_llama_index_llm_kwargs,
+        )
+
+        # service context to customize the models used by LlamaIndex
+        self._service_context = ServiceContext.from_defaults(
+            embed_model=embedding_model_id, llm=llm, **other_llama_index_service_context_kwargs
+        )
+        set_global_service_context(self._service_context)
+        nodes_sdk = self._service_context.node_parser.get_nodes_from_documents(docs_sdk)
+
+        # initialize storage context (by default it's in-memory)
+        self._storage_context = StorageContext.from_defaults(
+            **other_llama_index_storage_context_kwargs
+        )
+        self._storage_context.docstore.add_documents(nodes_sdk)
+
+        # create vector store index
+        self.index = VectorStoreIndex(
+            nodes_sdk,
+            service_context=self._service_context,
+            storage_context=self._storage_context,
+            **other_llama_index_vector_store_index_kwargs,
+        )
+
+        # configure retriever
+        self.retriever = VectorIndexRetriever(
+            index=self.index, **other_llama_index_vector_index_retriever_kwargs
+        )
+
+        # configure response synthesizer
+        self.response_synthesizer = get_response_synthesizer(
+            text_qa_template=PromptTemplate(qa_template_str)
+            if qa_template_str is not None
+            else None,
+            refine_template=PromptTemplate(refine_template_str)
+            if refine_template_str is not None
+            else None,
+            service_context=self._service_context,
+            **other_llama_index_response_synthesizer_kwargs,
+        )
+
+        # assemble query engine
+        self.query_engine = RetrieverQueryEngine(
+            retriever=self.retriever,
+            response_synthesizer=self.response_synthesizer,
+            **other_llama_index_retriever_query_engine_kwargs,
+        )
+
+    def _create_llama_index_llm(
+        self,
+        llm_model: str | LLM,
+        context_window: int = 1024,
+        generate_kwargs: Optional[dict] = None,
+        tokenizer_name: Optional[str] = None,
+        tokenizer_kwargs: Optional[dict] = None,
+        model_kwargs: Optional[dict] = None,
+        other_llama_index_llm_kwargs: dict = {},
+    ) -> LLM:
+        if isinstance(llm_model, str):
+            llm_provider, llm_id = llm_model.split(":")
+            if llm_provider == "openai":
+                return OpenAI(model=llm_id, **other_llama_index_llm_kwargs)
+            elif llm_provider == "hf":
+                return HuggingFaceLLM(
+                    context_window=context_window,
+                    generate_kwargs=generate_kwargs,
+                    tokenizer_name=llm_id if tokenizer_name is None else tokenizer_name,
+                    model_name=llm_id,
+                    tokenizer_kwargs=tokenizer_kwargs,
+                    model_kwargs=model_kwargs,
+                    **other_llama_index_llm_kwargs,
+                )
+            else:
+                raise NotImplementedError(
+                    f"LLM provider {llm_provider} is not implemented yet. Please check the documentation to see implemented providers."
+                )
+        elif isinstance(llm_model, LLM):
+            return llm_model
+        else:
+            raise ValueError(
+                f"`llm_model` is not a `str` nor a `llama_index.llms.base.LLM` object: {llm_model}"
+            )
+
+    def query(self, str_or_query_bundle: QueryType) -> RESPONSE_TYPE:
+        """Calls query method on the RetrieverQueryEngine.
+
+        Args:
+            str_or_query_bundle (`llama_index.indices.query.schema.QueryType`):
+                String or query bundle with the query to run.
+
+        Returns:
+            `llama_index.response.schema.RESPONSE_TYPE`: response from the LLM.
+        """
+
+        return self.query_engine.query(str_or_query_bundle)
+
+    def retrieve(self, str_or_query_bundle: QueryType) -> List[NodeWithScore]:
+        """Obtains the closest nodes to the query, computing the similarity of the query embedding
+        and the index embeddings.
+
+        Args:
+            str_or_query_bundle (`llama_index.indices.query.schema.QueryType`):
+                String or query bundle to get most similar stored nodes.
+
+        Returns:
+            `List[llama_index.schema.NodeWithScore]`: list with most similar nodes and their similarity score.
+        """
+
+        return self.retriever.retrieve(str_or_query_bundle)

--- a/poetry.lock
+++ b/poetry.lock
@@ -7153,6 +7153,28 @@ objc = ["pyobjc-framework-Cocoa"]
 win32 = ["pywin32"]
 
 [[package]]
+name = "sentence-transformers"
+version = "2.2.2"
+description = "Multilingual text embeddings"
+optional = false
+python-versions = ">=3.6.0"
+files = [
+    {file = "sentence-transformers-2.2.2.tar.gz", hash = "sha256:dbc60163b27de21076c9a30d24b5b7b6fa05141d68cf2553fa9a77bf79a29136"},
+]
+
+[package.dependencies]
+huggingface-hub = ">=0.4.0"
+nltk = "*"
+numpy = "*"
+scikit-learn = "*"
+scipy = "*"
+sentencepiece = "*"
+torch = ">=1.6.0"
+torchvision = "*"
+tqdm = "*"
+transformers = ">=4.6.0,<5.0.0"
+
+[[package]]
 name = "sentencepiece"
 version = "0.1.99"
 description = "SentencePiece python wrapper"
@@ -9265,4 +9287,4 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = "3.10.*"
-content-hash = "231d5a6c9a217aac80d16f6d790b1bdb450a6a8dc72e2804ba3d1f1e013b4757"
+content-hash = "7e1018699cf4dabf2f0c2a090d47d7669730061ca7f77108099f31a3c0e611c0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ sentencepiece = "^0.1.99"
 guidance = "^0.0.64"
 auto-gptq = "^0.4.2"
 optimum = "^1.12.0"
+sentence-transformers = "^2.2.2"
 
 
 [build-system]
@@ -101,6 +102,7 @@ dependencies = [
   "guidance>=0.0.64",
   "auto-gptq>=0.4.2",
   "optimum>=1.12.0",
+  "llama-index>=0.8.20",
 ]
 
 [project.optional-dependencies]
@@ -114,6 +116,7 @@ dev = [
 ]
 tests = [
   "pytest>=7.4.0",
+  "sentence-transformers>=2.2.2"
 ]
 
 [project.urls]

--- a/tests/kernels/test_auto_llama_index.py
+++ b/tests/kernels/test_auto_llama_index.py
@@ -1,0 +1,32 @@
+import os
+import tempfile
+from unittest.mock import patch
+
+import pytest
+from llama_index.query_engine import RetrieverQueryEngine
+from llama_index.retrievers import VectorIndexRetriever
+
+from openbb_chat.kernels.auto_llama_index import AutoLlamaIndex
+
+
+@patch.object(VectorIndexRetriever, "retrieve")
+@patch.object(RetrieverQueryEngine, "query")
+def test_auto_llama_index(mocked_query, mocked_retrieve):
+    # load testing models
+    autollamaindex = AutoLlamaIndex(
+        "./docs",
+        "local:sentence-transformers/all-MiniLM-L6-v2",
+        "hf:sshleifer/tiny-gpt2",
+        context_window=100,
+        other_llama_index_response_synthesizer_kwargs={"response_mode": "simple_summarize"},
+    )
+
+    query = "What is the purpose of Index.md"
+
+    # test retrieval
+    node_list = autollamaindex.retrieve(query)
+    mocked_retrieve.assert_called_once()
+
+    # test query
+    response = autollamaindex.query(query)
+    mocked_query.assert_called_once()


### PR DESCRIPTION
AutoLlamaIndex is a wrapper around LlamaIndex to easily create a vector index and, given a query, call an LLM over the retrieved results. LlamaIndex has many possible options regarding vector stores and LLMs, and in this first implementation only a simple vector store is included and only Hugging Face and OpenAI LLMs are accessible.

## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
List all the breaking changes introduced by this pull request.
-->

Integrates LlamaIndex as a new tool to be used, with a simple wrapper around its basic functionalities.

## Before submitting

- [x] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **test your PR locally** with `pytest` command?
- [x] Did you **run pre-commit hooks** with `pre-commit run -a` command?

## Did you have fun?

Make sure you had fun coding 🙃
