### PR TITLE
Add vector store index loading to AutoLlamaIndex

### DIFF
--- a/tests/kernels/test_auto_llama_index.py
+++ b/tests/kernels/test_auto_llama_index.py
@@ -3,6 +3,13 @@ import tempfile
 from unittest.mock import patch
 
 import pytest
+from llama_index import (
+    ServiceContext,
+    SimpleDirectoryReader,
+    StorageContext,
+    VectorStoreIndex,
+)
+from llama_index.llms import HuggingFaceLLM
 from llama_index.query_engine import RetrieverQueryEngine
 from llama_index.retrievers import VectorIndexRetriever
 
@@ -15,6 +22,55 @@ def test_auto_llama_index(mocked_query, mocked_retrieve):
     # load testing models
     autollamaindex = AutoLlamaIndex(
         "./docs",
+        "local:sentence-transformers/all-MiniLM-L6-v2",
+        "hf:sshleifer/tiny-gpt2",
+        context_window=100,
+        other_llama_index_response_synthesizer_kwargs={"response_mode": "simple_summarize"},
+    )
+
+    query = "What is the purpose of Index.md"
+
+    # test retrieval
+    node_list = autollamaindex.retrieve(query)
+    mocked_retrieve.assert_called_once()
+
+    # test query
+    response = autollamaindex.query(query)
+    mocked_query.assert_called_once()
+
+
+@patch.object(VectorIndexRetriever, "retrieve")
+@patch.object(RetrieverQueryEngine, "query")
+def test_auto_llama_index_persistance(mocked_query, mocked_retrieve):
+    # persist an index to test loading
+    docs_sdk = SimpleDirectoryReader("./docs", recursive=True).load_data()
+
+    # service context to customize the models used by LlamaIndex
+    service_context = ServiceContext.from_defaults(
+        embed_model="local:sentence-transformers/all-MiniLM-L6-v2",
+        llm=HuggingFaceLLM(
+            tokenizer_name="sshleifer/tiny-gpt2",
+            model_name="sshleifer/tiny-gpt2",
+        ),
+    )
+    nodes_sdk = service_context.node_parser.get_nodes_from_documents(docs_sdk)
+
+    # initialize storage context (by default it's in-memory)
+    storage_context = StorageContext.from_defaults()
+    storage_context.docstore.add_documents(nodes_sdk)
+
+    # create vector store index
+    index = VectorStoreIndex(
+        nodes_sdk,
+        show_progress=True,
+        service_context=service_context,
+        storage_context=storage_context,
+    )
+    index.storage_context.persist(persist_dir="./st")
+
+    # load testing models
+    autollamaindex = AutoLlamaIndex(
+        "vsi:./st",
         "local:sentence-transformers/all-MiniLM-L6-v2",
         "hf:sshleifer/tiny-gpt2",
         context_window=100,


### PR DESCRIPTION
This feature allows loading the vector store index from a persisted instance. The embedding model must match for the retrieval to make sense.

## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
List all the breaking changes introduced by this pull request.
-->

Adds the possibility to load a persisted vector store index to AutoLlamaIndex. The changes are tested with an unit test.

## Before submitting

- [x] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **test your PR locally** with `pytest` command?
- [x] Did you **run pre-commit hooks** with `pre-commit run -a` command?

## Did you have fun?

Make sure you had fun coding 🙃
