### PR TITLE
Add query with non-default models to AutoLlamaIndex

### DIFF
--- a/openbb_chat/retrievers/vector_bm25_retriever.py
+++ b/openbb_chat/retrievers/vector_bm25_retriever.py
@@ -1,0 +1,33 @@
+from llama_index.indices.query.schema import QueryType
+from llama_index.retrievers import BaseRetriever, VectorIndexRetriever
+
+
+class HybridORRetriever(BaseRetriever):
+    """Hybrid retriever based on the OR of two retrievers. Based on https://gpt-
+    index.readthedocs.io/en/latest/examples/retrievers/bm25_retriever.html#custom-retriever-
+    implementation.
+
+    Args:
+        retriever1 (`BaseRetriever`):
+            First retriever to use. It must extend `llama_index.retrievers.BaseRetriever`.
+        retriever2 (`BaseRetriever`):
+            Second retriever to use. It must extend `llama_index.retrievers.BaseRetriever`.
+    """
+
+    def __init__(self, retriever1: BaseRetriever, retriever2: BaseRetriever):
+        self.retriever1 = retriever1
+        self.retriever2 = retriever2
+
+    def _retrieve(self, query: QueryType, **kwargs):
+        """Override `_retrieve` from `BaseRetriever`."""
+        nodes2 = self.retriever2.retrieve(query, **kwargs)
+        nodes1 = self.retriever1.retrieve(query, **kwargs)
+
+        # combine the two lists of nodes
+        all_nodes = []
+        node_ids = set()
+        for n in nodes2 + nodes1:
+            if n.node.node_id not in node_ids:
+                all_nodes.append(n)
+                node_ids.add(n.node.node_id)
+        return all_nodes

--- a/poetry.lock
+++ b/poetry.lock
@@ -6429,6 +6429,23 @@ requests = ">=2.7.0"
 six = "*"
 
 [[package]]
+name = "rank-bm25"
+version = "0.2.2"
+description = "Various BM25 algorithms for document ranking"
+optional = false
+python-versions = "*"
+files = [
+    {file = "rank_bm25-0.2.2-py3-none-any.whl", hash = "sha256:7bd4a95571adadfc271746fa146a4bcfd89c0cf731e49c3d1ad863290adbe8ae"},
+    {file = "rank_bm25-0.2.2.tar.gz", hash = "sha256:096ccef76f8188563419aaf384a02f0ea459503fdf77901378d4fd9d87e5e51d"},
+]
+
+[package.dependencies]
+numpy = "*"
+
+[package.extras]
+dev = ["pytest"]
+
+[[package]]
 name = "rdflib"
 version = "7.0.0"
 description = "RDFLib is a Python library for working with RDF, a simple yet powerful language for representing information."
@@ -9287,4 +9304,4 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = "3.10.*"
-content-hash = "7e1018699cf4dabf2f0c2a090d47d7669730061ca7f77108099f31a3c0e611c0"
+content-hash = "c9239de3167ca9f3be7842c5056a6da7ad956e7eb99d24374e239172af101ab4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ guidance = "^0.0.64"
 auto-gptq = "^0.4.2"
 optimum = "^1.12.0"
 sentence-transformers = "^2.2.2"
+rank-bm25 = "^0.2.2"
 
 
 [build-system]
@@ -103,6 +104,7 @@ dependencies = [
   "auto-gptq>=0.4.2",
   "optimum>=1.12.0",
   "llama-index>=0.8.20",
+  "rank-bm25>=0.2.2",
 ]
 
 [project.optional-dependencies]

--- a/tests/kernels/test_auto_llama_index.py
+++ b/tests/kernels/test_auto_llama_index.py
@@ -86,3 +86,42 @@ def test_auto_llama_index_persistance(mocked_query, mocked_retrieve):
     # test query
     response = autollamaindex.query(query)
     mocked_query.assert_called_once()
+
+
+@patch.object(VectorIndexRetriever, "retrieve")
+@patch.object(RetrieverQueryEngine, "query")
+def test_auto_llama_index_query_with_model(mocked_query, mocked_retrieve):
+    # load testing models
+    autollamaindex = AutoLlamaIndex(
+        "./docs",
+        "local:sentence-transformers/all-MiniLM-L6-v2",
+        "hf:sshleifer/tiny-gpt2",
+        context_window=100,
+        other_llama_index_response_synthesizer_kwargs={"response_mode": "simple_summarize"},
+    )
+
+    query = "What is the purpose of Index.md"
+
+    # test query
+    response = autollamaindex.query_with_model(query, "hf:sshleifer/tiny-gpt2")
+    mocked_query.assert_called_once()
+
+
+@patch.object(VectorIndexRetriever, "retrieve")
+@patch.object(RetrieverQueryEngine, "synthesize")
+def test_auto_llama_index_synth(mocked_synthesize, mocked_retrieve):
+    # load testing models
+    autollamaindex = AutoLlamaIndex(
+        "./docs",
+        "local:sentence-transformers/all-MiniLM-L6-v2",
+        "hf:sshleifer/tiny-gpt2",
+        context_window=100,
+        other_llama_index_response_synthesizer_kwargs={"response_mode": "simple_summarize"},
+    )
+
+    query = "What is the purpose of Index.md"
+
+    # test query
+    node_list = autollamaindex.retrieve(query)
+    response = autollamaindex.synth(query, node_list)
+    mocked_synthesize.assert_called_once()


### PR DESCRIPTION
This functionality allows querying the database using an LLM different to the one specified during the construction of the AutoLlamaIndex object. It can be useful for API development.

Additionally, a new hybrid retriever is implemented based on the combination of the results of two separate retrievers. As a first approach, BM25 and vector retrievers are combined.

## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
List all the breaking changes introduced by this pull request.
-->

Allows to query the database with a different LLM than the one used to build the AutoLlamaIndex object.

## Before submitting

- [x] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **test your PR locally** with `pytest` command?
- [x] Did you **run pre-commit hooks** with `pre-commit run -a` command?

## Did you have fun?

Make sure you had fun coding 🙃
