### PR TITLE
Add retriever types' configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,6 +18,13 @@ repos:
       - id: check-added-large-files
         exclude: poetry.lock
 
+  # remove unused imports
+  - repo: https://github.com/hadialqattan/pycln
+    rev: v2.4.0
+    hooks:
+      - id: pycln
+        args: [--config=pyproject.toml]
+
   # python code formatting
   - repo: https://github.com/psf/black
     rev: 23.1.0

--- a/openbb_chat/kernels/__init__.py
+++ b/openbb_chat/kernels/__init__.py
@@ -1,0 +1,1 @@
+from .auto_llama_index import AutoLlamaIndex

--- a/openbb_chat/llms/__init__.py
+++ b/openbb_chat/llms/__init__.py
@@ -1,0 +1,2 @@
+from .chat_model_llm_iface import ChatModelWithLLMIface
+from .guidance_wrapper import GuidanceWrapper

--- a/tests/kernels/test_auto_llama_index.py
+++ b/tests/kernels/test_auto_llama_index.py
@@ -1,5 +1,3 @@
-import os
-import tempfile
 from unittest.mock import patch
 
 import pytest
@@ -11,7 +9,7 @@ from llama_index import (
 )
 from llama_index.llms import HuggingFaceLLM
 from llama_index.query_engine import RetrieverQueryEngine
-from llama_index.retrievers import VectorIndexRetriever
+from llama_index.retrievers import BM25Retriever, VectorIndexRetriever
 
 from openbb_chat.kernels.auto_llama_index import AutoLlamaIndex
 
@@ -125,3 +123,51 @@ def test_auto_llama_index_synth(mocked_synthesize, mocked_retrieve):
     node_list = autollamaindex.retrieve(query)
     response = autollamaindex.synth(query, node_list)
     mocked_synthesize.assert_called_once()
+
+
+@patch.object(VectorIndexRetriever, "retrieve")
+@patch.object(RetrieverQueryEngine, "query")
+def test_auto_llama_index_vector_retriever(mocked_query, mocked_retrieve):
+    # load testing models
+    autollamaindex = AutoLlamaIndex(
+        "./docs",
+        "local:sentence-transformers/all-MiniLM-L6-v2",
+        "hf:sshleifer/tiny-gpt2",
+        retriever_type="vector",
+        context_window=100,
+        other_llama_index_response_synthesizer_kwargs={"response_mode": "simple_summarize"},
+    )
+
+    query = "What is the purpose of Index.md"
+
+    # test retrieval
+    node_list = autollamaindex.retrieve(query)
+    mocked_retrieve.assert_called_once()
+
+    # test query
+    response = autollamaindex.query(query)
+    mocked_query.assert_called_once()
+
+
+@patch.object(BM25Retriever, "retrieve")
+@patch.object(RetrieverQueryEngine, "query")
+def test_auto_llama_index_bm25_retriever(mocked_query, mocked_retrieve):
+    # load testing models
+    autollamaindex = AutoLlamaIndex(
+        "./docs",
+        "local:sentence-transformers/all-MiniLM-L6-v2",
+        "hf:sshleifer/tiny-gpt2",
+        retriever_type="bm25",
+        context_window=100,
+        other_llama_index_response_synthesizer_kwargs={"response_mode": "simple_summarize"},
+    )
+
+    query = "What is the purpose of Index.md"
+
+    # test retrieval
+    node_list = autollamaindex.retrieve(query)
+    mocked_retrieve.assert_called_once()
+
+    # test query
+    response = autollamaindex.query(query)
+    mocked_query.assert_called_once()


### PR DESCRIPTION
BM25 retriever can be selected as its own retriever without the need of a vector retriever. This could be extended to use any type of llama-index retriever in the future. Also, a pre-commit hook is added to remove unused imports.

## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
List all the breaking changes introduced by this pull request.
-->

Adds a new variable `retriever_type` to select one retriever among 3:
- Vector: only vector search is done.
- BM25: uses this traditional algorithm to search instead of embeddings.
- Hybrid: uses an OR combination of the documents returned using both previous methods.

### Breaking changes
`use_hybrid_retriever` is substituted by `retriever_type`.

## Before submitting

- [x] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **test your PR locally** with `pytest` command?
- [x] Did you **run pre-commit hooks** with `pre-commit run -a` command?

## Did you have fun?

Make sure you had fun coding 🙃
